### PR TITLE
Add React profile with basic Three.js scene

### DIFF
--- a/my-app/public/index.html
+++ b/my-app/public/index.html
@@ -24,11 +24,12 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Personal Profile</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script src="https://unpkg.com/three@0.157.0/build/three.min.js"></script>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -1,38 +1,11 @@
 .App {
   text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
+  font-family: sans-serif;
 }
 
 .App-header {
   background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
   color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+  padding: 1rem;
+  font-size: 1.5rem;
 }

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -1,23 +1,13 @@
-import logo from './logo.svg';
 import './App.css';
+import ThreeScene from './components/ThreeScene';
+import Profile from './components/Profile';
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <header className="App-header">My Profile</header>
+      <ThreeScene />
+      <Profile />
     </div>
   );
 }

--- a/my-app/src/App.test.js
+++ b/my-app/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders profile heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /your name/i });
+  expect(heading).toBeInTheDocument();
 });

--- a/my-app/src/components/Profile.css
+++ b/my-app/src/components/Profile.css
@@ -1,0 +1,11 @@
+.profile {
+  text-align: center;
+  padding: 2rem;
+}
+
+.profile-img {
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  object-fit: cover;
+}

--- a/my-app/src/components/Profile.js
+++ b/my-app/src/components/Profile.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import './Profile.css';
+
+const Profile = () => (
+  <div className="profile">
+    <img
+      src="https://via.placeholder.com/150"
+      alt="Profile"
+      className="profile-img"
+    />
+    <h1>Your Name</h1>
+    <p>Hello! I'm building my personal website using React and Three.js.</p>
+  </div>
+);
+
+export default Profile;

--- a/my-app/src/components/ThreeScene.js
+++ b/my-app/src/components/ThreeScene.js
@@ -1,0 +1,47 @@
+import React, { useEffect, useRef } from 'react';
+
+const ThreeScene = () => {
+  const mountRef = useRef(null);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    const width = mount.clientWidth;
+    const height = mount.clientHeight;
+
+    // verify THREE is available
+    const THREE = window.THREE;
+    if (!THREE) {
+      console.error('Three.js not loaded');
+      return;
+    }
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(width, height);
+    mount.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+    camera.position.z = 2;
+
+    const geometry = new THREE.BoxGeometry();
+    const material = new THREE.MeshNormalMaterial();
+    const cube = new THREE.Mesh(geometry, material);
+    scene.add(cube);
+
+    const animate = () => {
+      cube.rotation.x += 0.01;
+      cube.rotation.y += 0.01;
+      renderer.render(scene, camera);
+      requestAnimationFrame(animate);
+    };
+    animate();
+
+    return () => {
+      mount.removeChild(renderer.domElement);
+    };
+  }, []);
+
+  return <div ref={mountRef} style={{ width: '100%', height: '300px' }} />;
+};
+
+export default ThreeScene;


### PR DESCRIPTION
## Summary
- create ThreeScene and Profile components
- update App to show 3D cube and profile info
- simplify styles and add Profile styles
- include Three.js via CDN and set title
- update test for new heading

## Testing
- `npm test --silent --color=always -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a10ae60cc83339e28cdef0344f148